### PR TITLE
Fix setting an excessive velocity

### DIFF
--- a/src/net/shortninja/staffplus/player/attribute/mode/handler/GadgetHandler.java
+++ b/src/net/shortninja/staffplus/player/attribute/mode/handler/GadgetHandler.java
@@ -94,7 +94,7 @@ public class GadgetHandler
 		
 		try{
 			player.setVelocity(vector.multiply(options.modeCompassVelocity));
-		catch(Exception ex){ }
+		} catch(Exception ex){ }
 	}
 	
 	public void onRandomTeleport(Player player, int count)

--- a/src/net/shortninja/staffplus/player/attribute/mode/handler/GadgetHandler.java
+++ b/src/net/shortninja/staffplus/player/attribute/mode/handler/GadgetHandler.java
@@ -1,5 +1,6 @@
 package net.shortninja.staffplus.player.attribute.mode.handler;
 
+import java.lang.Exception;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,9 @@ public class GadgetHandler
 	{
 		Vector vector = player.getLocation().getDirection();
 		
-		player.setVelocity(vector.multiply(options.modeCompassVelocity));
+		try{
+			player.setVelocity(vector.multiply(options.modeCompassVelocity));
+		catch(Exception ex){ }
 	}
 	
 	public void onRandomTeleport(Player player, int count)


### PR DESCRIPTION
Error:
```[22:23:18 WARN]: java.lang.Exception: Stack trace
[22:23:18 WARN]: 	at java.lang.Thread.dumpStack(Thread.java:1336)
[22:23:18 WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.entity.CraftEntity.setVelocity(CraftEntity.java:213)
[22:23:18 WARN]: 	at net.shortninja.staffplus.player.attribute.mode.handler.GadgetHandler.onCompass(GadgetHandler.java:94)
[22:23:18 WARN]: 	at net.shortninja.staffplus.server.listener.player.PlayerInteract.handleInteraction(PlayerInteract.java:71)
[22:23:18 WARN]: 	at net.shortninja.staffplus.server.listener.player.PlayerInteract.onInteract(PlayerInteract.java:53)
[22:23:18 WARN]: 	at sun.reflect.GeneratedMethodAccessor137.invoke(Unknown Source)
[22:23:18 WARN]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[22:23:18 WARN]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[22:23:18 WARN]: 	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300)
[22:23:18 WARN]: 	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78)
[22:23:18 WARN]: 	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62)
[22:23:18 WARN]: 	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:517)
[22:23:18 WARN]: 	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:502)
[22:23:18 WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:228)
[22:23:18 WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:195)
[22:23:18 WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:191)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:721)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:52)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:1)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.PlayerConnectionUtils$1.run(SourceFile:13)
[22:23:18 WARN]: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[22:23:18 WARN]: 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.SystemUtils.a(SourceFile:44)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:774)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:378)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:713)
[22:23:18 WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:616)
[22:23:18 WARN]: 	at java.lang.Thread.run(Thread.java:748)```